### PR TITLE
Add week-based time picker example

### DIFF
--- a/week_picker.html
+++ b/week_picker.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Week Picker</title>
+</head>
+<body>
+  <label for="week">Choose a week:</label>
+  <input type="week" id="week" name="week" />
+  <p id="output"></p>
+  <script>
+    const input = document.getElementById('week');
+    const output = document.getElementById('output');
+
+    input.addEventListener('change', () => {
+      output.textContent = `Selected week: ${input.value}`;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTML page with week-based time selector

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895722b7c2c8329b6ccfc5675a1910e